### PR TITLE
re-enable deformation based compression

### DIFF
--- a/src/draco/psy/psy_draco_decoder.cpp
+++ b/src/draco/psy/psy_draco_decoder.cpp
@@ -174,10 +174,10 @@ public:
 
     const ::draco::PointAttribute* GetPointAttributeByType(const ::draco::GeometryAttribute::Type type) const
     {
-        const int attrib_id = mpMesh->GetNamedAttributeId(type);
-        if (attrib_id >= 0)
+        const int vis_att_id = mpMesh->GetNamedAttributeId(type);
+        if (vis_att_id >= 0)
         {
-            return mpMesh->attribute(attrib_id);
+            return mpMesh->attribute(vis_att_id);
         }
         return nullptr;
     }
@@ -192,11 +192,6 @@ public:
         return GetPointAttributeByType(::draco::GeometryAttribute::COLOR);
     }
 
-    const ::draco::PointAttribute* GetTexCoordAttribute() const
-    {
-        return GetPointAttributeByType(::draco::GeometryAttribute::TEX_COORD);
-    }
-
     bool HasVisibilityInfo() const
     {
         return (nullptr != GetVisibilityAttribute());
@@ -207,17 +202,11 @@ public:
         return (nullptr != GetVertexColorAttribute());
     }
 
-    bool HasTexCoordInfo() const
-    {
-        return (nullptr != GetTexCoordAttribute());
-    }
-
     void GetMesh(int16_t* pVertices,
                  const size_t vertexStride,
                  unsigned int* pIndices,
                  unsigned char* pVisibilityAttributes,
-                 unsigned char* pVertexColorAttributes,
-                 unsigned char* pTexCoordAttributes) const
+                 unsigned char* pVertexColorAttributes) const
     {
         // update faces
         {
@@ -257,16 +246,6 @@ public:
                                           sizeof(uint8_t) * 3,
                                           mpMesh->num_points());
         }
-
-        // update tex coord attribute
-        if (nullptr != pTexCoordAttributes && HasTexCoordInfo())
-        {
-            UpdateGeometryAttributeValues(GetTexCoordAttribute(),
-                                          pTexCoordAttributes,
-                                          sizeof(float) * 2,
-                                          mpMesh->num_points());
-        }
-
     }
 
     Header mDecompressedHeader;
@@ -302,8 +281,7 @@ void MeshDecompression::GetMesh(int16_t* pVertices,
                                 const size_t vertexStride,
                                 unsigned int* pIndices,
                                 unsigned char* pVisibilityAttributes,
-                                unsigned char* pVertexColorAttributes,
-                                unsigned char* pTexCoordAttributes) const
+                                unsigned char* pVertexColorAttributes) const
 {
     if (mpImpl->mStatus.ok())
     {
@@ -311,8 +289,7 @@ void MeshDecompression::GetMesh(int16_t* pVertices,
                         vertexStride,
                         pIndices,
                         pVisibilityAttributes,
-                        pVertexColorAttributes,
-                        pTexCoordAttributes);
+                        pVertexColorAttributes);
     }
 }
 
@@ -357,15 +334,6 @@ bool MeshDecompression::HasVertexColorInfo() const
     if (mpImpl->mStatus.ok())
     {
         return mpImpl->HasVertexColorInfo();
-    }
-    return false;
-}
-
-bool MeshDecompression::hasTexCoordInfo() const
-{
-    if (mpImpl->mStatus.ok())
-    {
-        return mpImpl->HasTexCoordInfo();
     }
     return false;
 }

--- a/src/draco/psy/psy_draco_decoder.cpp
+++ b/src/draco/psy/psy_draco_decoder.cpp
@@ -263,7 +263,7 @@ public:
         {
             UpdateGeometryAttributeValues(GetTexCoordAttribute(),
                                           pTexCoordAttributes,
-                                          sizeof(uint8_t) * 8,
+                                          sizeof(float) * 2,
                                           mpMesh->num_points());
         }
 

--- a/src/draco/psy/psy_draco_decoder.cpp
+++ b/src/draco/psy/psy_draco_decoder.cpp
@@ -174,10 +174,10 @@ public:
 
     const ::draco::PointAttribute* GetPointAttributeByType(const ::draco::GeometryAttribute::Type type) const
     {
-        const int vis_att_id = mpMesh->GetNamedAttributeId(type);
-        if (vis_att_id >= 0)
+        const int attrib_id = mpMesh->GetNamedAttributeId(type);
+        if (attrib_id >= 0)
         {
-            return mpMesh->attribute(vis_att_id);
+            return mpMesh->attribute(attrib_id);
         }
         return nullptr;
     }
@@ -192,6 +192,11 @@ public:
         return GetPointAttributeByType(::draco::GeometryAttribute::COLOR);
     }
 
+    const ::draco::PointAttribute* GetTexCoordAttribute() const
+    {
+        return GetPointAttributeByType(::draco::GeometryAttribute::TEX_COORD);
+    }
+
     bool HasVisibilityInfo() const
     {
         return (nullptr != GetVisibilityAttribute());
@@ -202,11 +207,17 @@ public:
         return (nullptr != GetVertexColorAttribute());
     }
 
+    bool HasTexCoordInfo() const
+    {
+        return (nullptr != GetTexCoordAttribute());
+    }
+
     void GetMesh(int16_t* pVertices,
                  const size_t vertexStride,
                  unsigned int* pIndices,
                  unsigned char* pVisibilityAttributes,
-                 unsigned char* pVertexColorAttributes) const
+                 unsigned char* pVertexColorAttributes,
+                 unsigned char* pTexCoordAttributes) const
     {
         // update faces
         {
@@ -246,6 +257,16 @@ public:
                                           sizeof(uint8_t) * 3,
                                           mpMesh->num_points());
         }
+
+        // update tex coord attribute
+        if (nullptr != pTexCoordAttributes && HasTexCoordInfo())
+        {
+            UpdateGeometryAttributeValues(GetTexCoordAttribute(),
+                                          pTexCoordAttributes,
+                                          sizeof(uint8_t) * 8,
+                                          mpMesh->num_points());
+        }
+
     }
 
     Header mDecompressedHeader;
@@ -281,7 +302,8 @@ void MeshDecompression::GetMesh(int16_t* pVertices,
                                 const size_t vertexStride,
                                 unsigned int* pIndices,
                                 unsigned char* pVisibilityAttributes,
-                                unsigned char* pVertexColorAttributes) const
+                                unsigned char* pVertexColorAttributes,
+                                unsigned char* pTexCoordAttributes) const
 {
     if (mpImpl->mStatus.ok())
     {
@@ -289,7 +311,8 @@ void MeshDecompression::GetMesh(int16_t* pVertices,
                         vertexStride,
                         pIndices,
                         pVisibilityAttributes,
-                        pVertexColorAttributes);
+                        pVertexColorAttributes,
+                        pTexCoordAttributes);
     }
 }
 
@@ -334,6 +357,15 @@ bool MeshDecompression::HasVertexColorInfo() const
     if (mpImpl->mStatus.ok())
     {
         return mpImpl->HasVertexColorInfo();
+    }
+    return false;
+}
+
+bool MeshDecompression::hasTexCoordInfo() const
+{
+    if (mpImpl->mStatus.ok())
+    {
+        return mpImpl->HasTexCoordInfo();
     }
     return false;
 }

--- a/src/draco/psy/psy_draco_decoder.h
+++ b/src/draco/psy/psy_draco_decoder.h
@@ -40,11 +40,13 @@ public:
     size_t GetFacesCount() const;
     bool HasVisibilityInfo() const;
     bool HasVertexColorInfo() const;
+    bool hasTexCoordInfo() const;
     void GetMesh(int16_t* pVertices,
                  const size_t vertexStride,
                  unsigned int* pIndices,
                  unsigned char* pVisibilityAttributes,
-                 unsigned char* pVertexColorAttributes) const;
+                 unsigned char* pVertexColorAttributes,
+                 unsigned char* pTexCoordAttributes) const;
 
     const char* GetLastErrorMessage() const;
 

--- a/src/draco/psy/psy_draco_decoder.h
+++ b/src/draco/psy/psy_draco_decoder.h
@@ -40,13 +40,11 @@ public:
     size_t GetFacesCount() const;
     bool HasVisibilityInfo() const;
     bool HasVertexColorInfo() const;
-    bool hasTexCoordInfo() const;
     void GetMesh(int16_t* pVertices,
                  const size_t vertexStride,
                  unsigned int* pIndices,
                  unsigned char* pVisibilityAttributes,
-                 unsigned char* pVertexColorAttributes,
-                 unsigned char* pTexCoordAttributes) const;
+                 unsigned char* pVertexColorAttributes) const;
 
     const char* GetLastErrorMessage() const;
 

--- a/src/draco/psy/psy_draco_decoder.h
+++ b/src/draco/psy/psy_draco_decoder.h
@@ -32,14 +32,16 @@ public:
     ~MeshDecompression();
 
     eStatus Run(const char* pCompressedData,
-                const size_t compressedDataSizeInBytes);
+                const size_t compressedDataSizeInBytes,
+                float* pDecodeMultiplier);
 
+    const Header* GetDecompressedHeader() const;
     size_t GetVerticesCount() const;
     size_t GetFacesCount() const;
     bool HasVisibilityInfo() const;
     bool HasVertexColorInfo() const;
     bool hasTexCoordInfo() const;
-    void GetMesh(float* pVertices,
+    void GetMesh(int16_t* pVertices,
                  const size_t vertexStride,
                  unsigned int* pIndices,
                  unsigned char* pVisibilityAttributes,

--- a/src/draco/psy/psy_draco_encoder.cpp
+++ b/src/draco/psy/psy_draco_encoder.cpp
@@ -117,12 +117,10 @@ class MeshCompression::Impl
 public:
     Impl(int compressionLevel,
          bool hasVisibilityInfo,
-         bool hasVertexColorInfo,
-         bool hasTexCoordInfo) :
+         bool hasVertexColorInfo) :
         mCompressionLevel(compressionLevel),
         mHasVisibilityInfo(hasVisibilityInfo),
         mHasVertexColorInfo(hasVertexColorInfo),
-        mHasTexCoordInfo(hasTexCoordInfo),
         mPositionAttributeId(0),
         mVertexColorAttributeId(-1),
         mVisibilityAttributeId(-1)
@@ -138,7 +136,7 @@ public:
 
             ::draco::GeometryAttribute pos_attrib;
             pos_attrib.Init(::draco::GeometryAttribute::POSITION,
-                            nullptr, 3, ::draco::DT_FLOAT32, false, sizeof(float) * 3, 0);
+                            nullptr, 3, ::draco::DT_INT16, false, sizeof(int16_t) * 3, 0);
             mPositionAttributeId = mpMesh->AddAttribute(pos_attrib, true, 0);
 
             if (mHasVisibilityInfo)
@@ -160,14 +158,6 @@ public:
                 num_attribs++;
             }
 
-            if (mHasTexCoordInfo)
-            {
-                ::draco::GeometryAttribute tex_coord_attrib;
-                tex_coord_attrib.Init(::draco::GeometryAttribute::TEX_COORD, nullptr, 2, ::draco::DT_FLOAT32, false, sizeof(uint8_t) * 8, 0);
-                mTexCoordAttributeId = mpMesh->AddAttribute(tex_coord_attrib, true, 0);
-                num_attribs++;
-            }
-
             // Convert compression level to speed (that 0 = slowest, 10 = fastest).
             const int speed = MAX_COMPRESSION_LEVEL - mCompressionLevel;
             mpCompressionOptions->SetGlobalInt("encoding_speed", speed);
@@ -184,7 +174,7 @@ public:
     }
 
     void ResetGeometryAttributeValues(const size_t verticesCount,
-                                      ::draco::PointAttribute* pPointAttribute)
+                                       ::draco::PointAttribute* pPointAttribute)
     {
         pPointAttribute->SetIdentityMapping();
         pPointAttribute->Resize(verticesCount);
@@ -218,7 +208,7 @@ public:
         }
     } // UpdateGeometryAttributeValues
 
-    MeshCompression::eStatus Run(const float* pVertices,
+    MeshCompression::eStatus Run(const int16_t* pVertices,
                                  const size_t vertexStride,
                                  const size_t verticesCount,
                                  const float decodeMultiplier,
@@ -226,7 +216,6 @@ public:
                                  const size_t indicesCount,
                                  const unsigned char* pVisibilityAttributes,
                                  const unsigned char* pVertexColorAttributes,
-                                 const unsigned char* pTexCoordAttributes,
                                  const MeshType meshType,
                                  uint32_t IFrameIndex)
     {
@@ -236,6 +225,21 @@ public:
 
         // reset encode buffer
         mpBuffer->Resize(0);
+
+        // encode header
+        {
+            mHeader.mMajorVersion = PSY_DRACO_API_MAJOR_VERSION;
+            mHeader.mMinorVersion = PSY_DRACO_API_MINOR_VERSION;
+            mHeader.mDecodeMultiplier = decodeMultiplier;
+            mHeader.mMeshType = meshType;
+            mHeader.mIFrameIndex = IFrameIndex;
+
+            if (!mpBuffer->Encode(&mHeader, sizeof(mHeader)))
+            {
+                mStatus = ::draco::Status(::draco::Status::Code::ERROR, "Failed to encode header.");
+                return eStatus::FAILED;
+            }
+        }
 
         // update faces if need
         if (false == is_incremental_compression)
@@ -294,18 +298,6 @@ public:
                                                  mpMesh->attribute(mVertexColorAttributeId));
                 }
             }
-
-            // update uv info
-            if (mTexCoordAttributeId >= 0)
-            {
-                assert(nullptr != pTexCoordAttributes);
-                {
-                    UpdateGeometryAttributeValues(pTexCoordAttributes,
-                                                  sizeof(float) * 2,
-                                                  verticesCount,
-                                                  mpMesh->attribute(mTexCoordAttributeId));
-                }
-            }
         }
 
         // run compression
@@ -325,13 +317,12 @@ public:
     int mCompressionLevel;
     bool mHasVisibilityInfo;
     bool mHasVertexColorInfo;
-    bool mHasTexCoordInfo;
 
     int mPositionAttributeId;
     int mVertexColorAttributeId;
     int mVisibilityAttributeId;
-    int mTexCoordAttributeId;
 
+    Header mHeader;
     std::unique_ptr<::draco::Mesh> mpMesh;
     std::shared_ptr<::draco::EncoderBuffer> mpBuffer;
     std::unique_ptr<CompressionOptions> mpCompressionOptions;
@@ -347,13 +338,11 @@ MeshCompression& MeshCompression::operator=(const MeshCompression&)
 
 MeshCompression::MeshCompression(int compressionLevel,
                                  bool hasVisibilityInfo,
-                                 bool hasVertexColorInfo,
-                                 bool hasTexCoordInfo)
+                                 bool hasVertexColorInfo)
 {
     mpImpl = new Impl(compressionLevel,
                       hasVisibilityInfo,
-                      hasVertexColorInfo,
-                      hasTexCoordInfo);
+                      hasVertexColorInfo);
 }
 
 MeshCompression::~MeshCompression()
@@ -375,12 +364,7 @@ bool MeshCompression::IsVertexColorInfoCompressing() const
     return mpImpl->mHasVertexColorInfo;
 }
 
-bool MeshCompression::IsTexCoordInfoCompressing() const
-{
-    return mpImpl->mHasTexCoordInfo;
-}
-
-MeshCompression::eStatus MeshCompression::Run(const float* pVertices,
+MeshCompression::eStatus MeshCompression::Run(const int16_t* pVertices,
         const size_t vertexStride,
         const size_t verticesCount,
         const float decodeMultiplier,
@@ -388,7 +372,6 @@ MeshCompression::eStatus MeshCompression::Run(const float* pVertices,
         const size_t indicesCount,
         const unsigned char* pVisibilityAttributes,
         const unsigned char* pVertexColorAttributes,
-        const unsigned char* pTexCoordAttributes,
         const MeshType meshType,
         uint32_t IFrameIndex)
 {
@@ -400,7 +383,6 @@ MeshCompression::eStatus MeshCompression::Run(const float* pVertices,
                        indicesCount,
                        pVisibilityAttributes,
                        pVertexColorAttributes,
-                       pTexCoordAttributes,
                        meshType,
                        IFrameIndex);
 }

--- a/src/draco/psy/psy_draco_encoder.cpp
+++ b/src/draco/psy/psy_draco_encoder.cpp
@@ -125,7 +125,8 @@ public:
         mHasTexCoordInfo(hasTexCoordInfo),
         mPositionAttributeId(0),
         mVertexColorAttributeId(-1),
-        mVisibilityAttributeId(-1)
+        mVisibilityAttributeId(-1),
+        mTexCoordAttributeId(-1)
     {
         mCompressionLevel = std::max(0, std::min(MAX_COMPRESSION_LEVEL, mCompressionLevel));
 

--- a/src/draco/psy/psy_draco_encoder.cpp
+++ b/src/draco/psy/psy_draco_encoder.cpp
@@ -117,10 +117,12 @@ class MeshCompression::Impl
 public:
     Impl(int compressionLevel,
          bool hasVisibilityInfo,
-         bool hasVertexColorInfo) :
+         bool hasVertexColorInfo,
+         bool hasTexCoordInfo) :
         mCompressionLevel(compressionLevel),
         mHasVisibilityInfo(hasVisibilityInfo),
         mHasVertexColorInfo(hasVertexColorInfo),
+        mHasTexCoordInfo(hasTexCoordInfo),
         mPositionAttributeId(0),
         mVertexColorAttributeId(-1),
         mVisibilityAttributeId(-1)
@@ -158,6 +160,14 @@ public:
                 num_attribs++;
             }
 
+            if (mHasTexCoordInfo)
+            {
+                ::draco::GeometryAttribute tex_coord_attrib;
+                tex_coord_attrib.Init(::draco::GeometryAttribute::TEX_COORD, nullptr, 3, ::draco::DT_UINT8, false, sizeof(uint8_t) * 3, 0);
+                mTexCoordAttributeId = mpMesh->AddAttribute(tex_coord_attrib, true, 0);
+                num_attribs++;
+            }
+
             // Convert compression level to speed (that 0 = slowest, 10 = fastest).
             const int speed = MAX_COMPRESSION_LEVEL - mCompressionLevel;
             mpCompressionOptions->SetGlobalInt("encoding_speed", speed);
@@ -174,7 +184,7 @@ public:
     }
 
     void ResetGeometryAttributeValues(const size_t verticesCount,
-                                       ::draco::PointAttribute* pPointAttribute)
+                                      ::draco::PointAttribute* pPointAttribute)
     {
         pPointAttribute->SetIdentityMapping();
         pPointAttribute->Resize(verticesCount);
@@ -216,6 +226,7 @@ public:
                                  const size_t indicesCount,
                                  const unsigned char* pVisibilityAttributes,
                                  const unsigned char* pVertexColorAttributes,
+                                 const unsigned char* pTexCoordAttributes,
                                  const MeshType meshType,
                                  uint32_t IFrameIndex)
     {
@@ -298,6 +309,18 @@ public:
                                                  mpMesh->attribute(mVertexColorAttributeId));
                 }
             }
+
+            // update uv info
+            if (mTexCoordAttributeId >= 0)
+            {
+                assert(nullptr != pTexCoordAttributes);
+                {
+                    UpdateGeometryAttributeValues(pTexCoordAttributes,
+                                                  sizeof(uint8_t) * 8,
+                                                  verticesCount,
+                                                  mpMesh->attribute(mTexCoordAttributeId));
+                }
+            }
         }
 
         // run compression
@@ -317,10 +340,12 @@ public:
     int mCompressionLevel;
     bool mHasVisibilityInfo;
     bool mHasVertexColorInfo;
+    bool mHasTexCoordInfo;
 
     int mPositionAttributeId;
     int mVertexColorAttributeId;
     int mVisibilityAttributeId;
+    int mTexCoordAttributeId;
 
     Header mHeader;
     std::unique_ptr<::draco::Mesh> mpMesh;
@@ -338,11 +363,13 @@ MeshCompression& MeshCompression::operator=(const MeshCompression&)
 
 MeshCompression::MeshCompression(int compressionLevel,
                                  bool hasVisibilityInfo,
-                                 bool hasVertexColorInfo)
+                                 bool hasVertexColorInfo,
+                                 bool hasTexCoordInfo)
 {
     mpImpl = new Impl(compressionLevel,
                       hasVisibilityInfo,
-                      hasVertexColorInfo);
+                      hasVertexColorInfo,
+                      hasTexCoordInfo);
 }
 
 MeshCompression::~MeshCompression()
@@ -364,6 +391,11 @@ bool MeshCompression::IsVertexColorInfoCompressing() const
     return mpImpl->mHasVertexColorInfo;
 }
 
+bool MeshCompression::IsTexCoordInfoCompressing() const
+{
+    return mpImpl->mHasTexCoordInfo;
+}
+
 MeshCompression::eStatus MeshCompression::Run(const int16_t* pVertices,
         const size_t vertexStride,
         const size_t verticesCount,
@@ -372,6 +404,7 @@ MeshCompression::eStatus MeshCompression::Run(const int16_t* pVertices,
         const size_t indicesCount,
         const unsigned char* pVisibilityAttributes,
         const unsigned char* pVertexColorAttributes,
+        const unsigned char* pTexCoordAttributes,
         const MeshType meshType,
         uint32_t IFrameIndex)
 {
@@ -383,6 +416,7 @@ MeshCompression::eStatus MeshCompression::Run(const int16_t* pVertices,
                        indicesCount,
                        pVisibilityAttributes,
                        pVertexColorAttributes,
+                       pTexCoordAttributes,
                        meshType,
                        IFrameIndex);
 }

--- a/src/draco/psy/psy_draco_encoder.cpp
+++ b/src/draco/psy/psy_draco_encoder.cpp
@@ -163,7 +163,7 @@ public:
             if (mHasTexCoordInfo)
             {
                 ::draco::GeometryAttribute tex_coord_attrib;
-                tex_coord_attrib.Init(::draco::GeometryAttribute::TEX_COORD, nullptr, 3, ::draco::DT_UINT8, false, sizeof(uint8_t) * 3, 0);
+                tex_coord_attrib.Init(::draco::GeometryAttribute::TEX_COORD, nullptr, 2, ::draco::DT_FLOAT32, false, sizeof(uint8_t) * 8, 0);
                 mTexCoordAttributeId = mpMesh->AddAttribute(tex_coord_attrib, true, 0);
                 num_attribs++;
             }
@@ -316,7 +316,7 @@ public:
                 assert(nullptr != pTexCoordAttributes);
                 {
                     UpdateGeometryAttributeValues(pTexCoordAttributes,
-                                                  sizeof(uint8_t) * 8,
+                                                  sizeof(float) * 2,
                                                   verticesCount,
                                                   mpMesh->attribute(mTexCoordAttributeId));
                 }

--- a/src/draco/psy/psy_draco_encoder.h
+++ b/src/draco/psy/psy_draco_encoder.h
@@ -41,17 +41,14 @@ public:
     */
     MeshCompression(int compressionLevel,
                     bool hasVisibilityInfo = false,
-                    bool hasVerttexColorInfo = false,
-                    bool hasTexCoordInfo = false);
+                    bool hasVerttexColorInfo = false);
     ~MeshCompression();
 
     bool IsVisiblityInfoCompressing() const;
 
     bool IsVertexColorInfoCompressing() const;
 
-    bool IsTexCoordInfoCompressing() const;
-
-    eStatus Run(const float* pQuantizedVertices,
+    eStatus Run(const int16_t* pQuantizedVertices,
                 const size_t vertexStride,
                 const size_t verticesCount,
                 const float decodeMultiplier,
@@ -59,7 +56,6 @@ public:
                 const size_t indicesCount,
                 const unsigned char* pVisibilityAttributes,
                 const unsigned char* pVertexColorAttributes,
-                const unsigned char* pTexCoordAttributes,
                 const MeshType meshType,
                 uint32_t IFrameIndex);
 

--- a/src/draco/psy/psy_draco_encoder.h
+++ b/src/draco/psy/psy_draco_encoder.h
@@ -41,12 +41,15 @@ public:
     */
     MeshCompression(int compressionLevel,
                     bool hasVisibilityInfo = false,
-                    bool hasVerttexColorInfo = false);
+                    bool hasVerttexColorInfo = false,
+                    bool hasTexCoordInfo = false);
     ~MeshCompression();
 
     bool IsVisiblityInfoCompressing() const;
 
     bool IsVertexColorInfoCompressing() const;
+
+    bool IsTexCoordInfoCompressing() const;
 
     eStatus Run(const int16_t* pQuantizedVertices,
                 const size_t vertexStride,
@@ -56,6 +59,7 @@ public:
                 const size_t indicesCount,
                 const unsigned char* pVisibilityAttributes,
                 const unsigned char* pVertexColorAttributes,
+                const unsigned char* pTexCoordAttributes,
                 const MeshType meshType,
                 uint32_t IFrameIndex);
 

--- a/src/draco/psy/psy_draco_encoder.h
+++ b/src/draco/psy/psy_draco_encoder.h
@@ -40,6 +40,7 @@ public:
     *     1 for visible and 0 for invisible
     */
     MeshCompression(int compressionLevel,
+                    int texCoordQuantizationBitsCount = 0,
                     bool hasVisibilityInfo = false,
                     bool hasVerttexColorInfo = false,
                     bool hasTexCoordInfo = false);


### PR DESCRIPTION
This rolls back the changes to enable deformation based compression. This also opens the api to accept a quantization parameter for the texture coords.

//cc @DillonSkeehan @jstys92 @svensht2 